### PR TITLE
escape paths before executing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 var child_process = require('child_process');
 var exec  = child_process.exec;
 var fs = require('fs-extra');
+var escape = function(input) {return require('shell-escape')([input])}
 
 
 var UnrarModule = function(options){
@@ -10,7 +11,8 @@ var UnrarModule = function(options){
 
 UnrarModule.prototype.extract = function (dstPath, options, cb) {
 	var _self = this;
-	
+  dstPath = escape(dstPath);
+
 	fs.ensureDir(dstPath, function(err){
 	  if(err) cb(new Error('Failed to create Folder Hierarchy'));
 	  _self._execute(['e'], dstPath, function(err, data){
@@ -24,7 +26,7 @@ UnrarModule.prototype.extract = function (dstPath, options, cb) {
 
 UnrarModule.prototype._execute = function (args, dstPath, cb) {
   var args = args;
-  var execCommand = "unrar " + args.join() + ' ' + this._filePath;
+  var execCommand = "unrar " + args.join() + ' ' + escape(this._filePath);
 
   if(dstPath) execCommand += ' ' + dstPath;
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "fs-extra": "^0.24.0"
+    "fs-extra": "^0.24.0",
+    "shell-escape": "^0.2.0"
   }
 }


### PR DESCRIPTION
This ensures that commands will not fail with spaces or other unusual characters in the `filepath` or `dstPath`.

It seems to me that this should live in the module rather than escaping input prior to calling unrar.
Thoughts?
