### PR TITLE
removed fs-extra, which created folders surrounded by single quotes('')

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 .idea
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Utilize a second argument as an options object for password protected rar's and 
 
 ## License
 
-Apache-2.0 © 
+Apache-2.0 ©
 
 
 [npm-image]: https://badge.fury.io/js/node-unrar.svg
 [npm-url]: https://npmjs.org/package/node-unrar
-[travis-image]: https://travis-ci.org/scopsy/node-unrar.svg?branch=master
-[travis-url]: https://travis-ci.org/scopsy/node-unrar
-[daviddm-image]: https://david-dm.org/scopsy/node-unrar.svg?theme=shields.io
-[daviddm-url]: https://david-dm.org/scopsy/node-unrar
+[travis-image]: https://travis-ci.org/alice-em/node-unrar.svg?branch=master
+[travis-url]: https://travis-ci.org/alice-em/node-unrar
+[daviddm-image]: https://david-dm.org/alice-em/node-unrar.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/alice-em/node-unrar

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You must install `unrar` from rarlab website and put it in your PATH.
 ## Example
 
 ```js
-var Unrar = require('node-unrar');
+var Unrar = require('node-unrar-update');
 
 var rar = new Unrar('/path/to/file.rar');
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ var Unrar = require('node-unrar');
 
 var rar = new Unrar('/path/to/file.rar');
 
+/// Create '/path/to/dest/' before rar.extract()
+
 rar.extract('/path/to/dest/', null, function (err) {
     //file extracted succesfully.
 });

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ You must install `unrar` from rarlab website and put it in your PATH.
 ## Example
 
 ```js
-var Unrar = require('node-unrar-update');
+var Unrar = require('node-unrar');
 
 var rar = new Unrar('/path/to/file.rar');
 
 /// Create '/path/to/dest/' before rar.extract()
 
 rar.extract('/path/to/dest/', null, function (err) {
-    //file extracted succesfully.
+    //file extracted successfully.
 });
 ```
 
 ## TODO
-Utilize a second argument as an options object for password protected rar's and other avilable options.
+Utilize a second argument as an options object for password protected rar's and other available options.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Apache-2.0 ©
 
 
 [npm-image]: https://badge.fury.io/js/node-unrar.svg
-[npm-url]: https://npmjs.org/package/node-unrar
+[npm-url]: https://npmjs.org/package/node-unrar-update
 [travis-image]: https://travis-ci.org/alice-em/node-unrar.svg?branch=master
 [travis-url]: https://travis-ci.org/alice-em/node-unrar
 [daviddm-image]: https://david-dm.org/alice-em/node-unrar.svg?theme=shields.io

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Apache-2.0 ©
 
 
 [npm-image]: https://badge.fury.io/js/node-unrar.svg
-[npm-url]: https://npmjs.org/package/node-unrar-update
-[travis-image]: https://travis-ci.org/alice-em/node-unrar.svg?branch=master
-[travis-url]: https://travis-ci.org/alice-em/node-unrar
-[daviddm-image]: https://david-dm.org/alice-em/node-unrar.svg?theme=shields.io
-[daviddm-url]: https://david-dm.org/alice-em/node-unrar
+[npm-url]: https://npmjs.org/package/node-unrar
+[travis-image]: https://travis-ci.org/scopsy/node-unrar.svg?branch=master
+[travis-url]: https://travis-ci.org/scopsy/node-unrar
+[daviddm-image]: https://david-dm.org/scopsy/node-unrar.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/scopsy/node-unrar

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,42 +1,39 @@
 'use strict';
 var child_process = require('child_process');
-var exec  = child_process.exec;
-var fs = require('fs-extra');
-var escape = function(input) {return require('shell-escape')([input])}
-
-
-var UnrarModule = function(options){
-  this._filePath = options.path || options;
-};
-
-UnrarModule.prototype.extract = function (dstPath, options, cb) {
-	var _self = this;
-  dstPath = escape(dstPath);
-
-	fs.ensureDir(dstPath, function(err){
-	  if(err) cb(new Error('Failed to create Folder Hierarchy'));
-	  _self._execute(['e'], dstPath, function(err, data){
-		if(err) return;
-
-		cb();
-	  });
-	});
-
+var exec = child_process.exec;
+var escape = function(input) {
+    return require('shell-escape')([input])
 }
 
-UnrarModule.prototype._execute = function (args, dstPath, cb) {
-  var args = args;
-  var execCommand = "unrar " + args.join() + ' ' + escape(this._filePath);
+var UnrarModule = function(options) {
+    this._filePath = options.path || options;
+};
 
-  if(dstPath) execCommand += ' ' + dstPath;
+UnrarModule.prototype.extract = function(dstPath, options, cb) {
+    var _self = this;
+    dstPath = escape(dstPath);
 
-  exec(execCommand, function (err, stdout, stderr) {
-    if(err) cb(new Error(err));
-    if (stdout.length > 0 && stdout.match(/.*not RAR archive.*/g)) { return done(new Error('Unsupported RAR.')); }
+    _self._execute(['e'], dstPath, function(err, data) {
+        if (err) return;
 
-    cb(null, stdout);
+        cb();
+    });
+}
 
-  });
+UnrarModule.prototype._execute = function(args, dstPath, cb) {
+    var args = args;
+    var execCommand = "unrar " + args.join() + ' ' + escape(this._filePath);
+
+    if (dstPath) execCommand += ' ' + dstPath;
+
+    exec(execCommand, function(err, stdout, stderr) {
+        if (err) cb(new Error(err));
+        if (stdout.length > 0 && stdout.match(/.*not RAR archive.*/g)) {
+            return done(new Error('Unsupported RAR.'));
+        }
+
+        cb(null, stdout);
+    });
 }
 
 module.exports = UnrarModule;

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "node-unrar-update",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Unrar wrapper for Node-js.",
   "homepage": "",
-  "repository": "alice-em/node-unrar",
+  "repository": "scopsy/node-unrar",
   "author": {
-    "name": "Dima Grossman, edits by Alice Maldonado",
-    "email": "dima@grossman.io, edits by the.alice.maldonado@gmail.com",
+    "name": "Dima Grossman",
+    "email": "dima@grossman.io",
     "url": ""
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "node-unrar",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Unrar wrapper for Node-js.",
   "homepage": "",
-  "repository": "scopsy/node-unrar",
+  "repository": "alice-em/node-unrar",
   "author": {
     "name": "Dima Grossman, edits by Alice Maldonado",
-    "email": "dima@grossman.io",
+    "email": "dima@grossman.io, edits by the.alice.maldonado@gmail.com",
     "url": ""
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "",
   "repository": "scopsy/node-unrar",
   "author": {
-    "name": "Dima Grossman",
+    "name": "Dima Grossman, edits by Alice Maldonado",
     "email": "dima@grossman.io",
     "url": ""
   },
@@ -34,7 +34,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "fs-extra": "^0.24.0",
     "shell-escape": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-unrar",
+  "name": "node-unrar-update",
   "version": "0.2.0",
   "description": "Unrar wrapper for Node-js.",
   "homepage": "",


### PR DESCRIPTION
FS-extra was causing an issue where `fs.ensureDir` created directories like `'path/to/folder/'`, which in the end the files didn't get extracted to, but instead the intended `path/to/folder`.  The developer will need to create the directory beforehand for the files to be extracted into.
